### PR TITLE
Update train_sb3.py for latest version of stable baselines

### DIFF
--- a/qwop_gym/tools/train_sb3.py
+++ b/qwop_gym/tools/train_sb3.py
@@ -36,6 +36,9 @@ class LogCallback(BaseCallback):
         for k in common.INFO_KEYS:
             v = safe_mean([ep_info[k] for ep_info in self.model.ep_info_buffer])
             self.model.logger.record(f"user/{k}", v)
+        return True
+
+    on_step = _on_step  # Fixes a bug with the latest version of SB3.
 
 
 def init_model(


### PR DESCRIPTION
Fixes a bug and updates compat.

---

In my usage, training would immediately cease after a single step when trying to train using SB3. Looking into it a bit more, the issue is this function is expected to return True or False depending on whether or not the training should continue.
https://github.com/DLR-RM/stable-baselines3/blob/84f5511e08b38b57f75240c287d62f441753a116/stable_baselines3/common/on_policy_algorithm.py#L250

The alias is because callbacks need `on_step` methods.
https://github.com/DLR-RM/stable-baselines3/blob/84f5511e08b38b57f75240c287d62f441753a116/stable_baselines3/common/on_policy_algorithm.py#L184C25-L184C32